### PR TITLE
Add shell script to run CCU on Linux

### DIFF
--- a/CCU Folder/CCU.sh
+++ b/CCU Folder/CCU.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+java -jar CCU.jar


### PR DESCRIPTION
Add CCU.sh script to allow Linux users to double-click on CCU.sh to run CCU rather than using the command
```
java -jar CCU.jar
```
each time they want to run it.